### PR TITLE
Make st_info and st_other fully public

### DIFF
--- a/src/symbol.rs
+++ b/src/symbol.rs
@@ -53,10 +53,10 @@ pub struct Symbol {
     pub st_shndx: u16,
 
     /// This member specifies the symbol's type and binding attributes.
-    pub(super) st_info: u8,
+    pub st_info: u8,
 
     /// This member currently specifies a symbol's visibility.
-    pub(super) st_other: u8,
+    pub st_other: u8,
 
     /// This member gives the value of the associated symbol. Depending on the
     /// context, this may be an absolute value, an address, and so on.


### PR DESCRIPTION
Make st_info and st_other public fields for symbol. This is required when parsing non-standard ELF files that might store format-specific information into these fields